### PR TITLE
jit compiler used successfully

### DIFF
--- a/.ipynb_checkpoints/1-checkpoint.ipynb
+++ b/.ipynb_checkpoints/1-checkpoint.ipynb
@@ -2,13 +2,14 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "8d606de9",
+   "execution_count": 7,
+   "id": "1680390a",
    "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np \n",
-    "import pandas as pd\n",
+    "#import pandas as pd\n",
+    "import numba\n",
     "\n",
     "a = np.arange(0, 100).reshape((10, 10))"
    ]
@@ -16,7 +17,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "63fe07a9",
+   "id": "310db278",
    "metadata": {},
    "outputs": [
     {
@@ -46,7 +47,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "2423b0ae",
+   "id": "faa10de1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,8 +57,10 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "eea41ce0",
-   "metadata": {},
+   "id": "1b3f8390",
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
      "data": {
@@ -81,6 +84,89 @@
    ],
    "source": [
     "b"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "b41bf00e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 5 µs, sys: 5 µs, total: 10 µs\n",
+      "Wall time: 27.2 µs\n",
+      "[[   0    1    4    9   16   25   36   49   64   81]\n",
+      " [ 100  121  144  169  196  225  256  289  324  361]\n",
+      " [ 400  441  484  529  576  625  676  729  784  841]\n",
+      " [ 900  961 1024 1089 1156 1225 1296 1369 1444 1521]\n",
+      " [1600 1681 1764 1849 1936 2025 2116 2209 2304 2401]\n",
+      " [2500 2601 2704 2809 2916 3025 3136 3249 3364 3481]\n",
+      " [3600 3721 3844 3969 4096 4225 4356 4489 4624 4761]\n",
+      " [4900 5041 5184 5329 5476 5625 5776 5929 6084 6241]\n",
+      " [6400 6561 6724 6889 7056 7225 7396 7569 7744 7921]\n",
+      " [8100 8281 8464 8649 8836 9025 9216 9409 9604 9801]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "%time\n",
+    "print(a*b)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "cc136a95",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@numba.jit\n",
+    "def f(x, y):\n",
+    "    print (x*y)\n",
+    "    return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "f2931e0c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 4 µs, sys: 1e+03 ns, total: 5 µs\n",
+      "Wall time: 14.1 µs\n",
+      "[[   0    1    4    9   16   25   36   49   64   81]\n",
+      " [ 100  121  144  169  196  225  256  289  324  361]\n",
+      " [ 400  441  484  529  576  625  676  729  784  841]\n",
+      " [ 900  961 1024 1089 1156 1225 1296 1369 1444 1521]\n",
+      " [1600 1681 1764 1849 1936 2025 2116 2209 2304 2401]\n",
+      " [2500 2601 2704 2809 2916 3025 3136 3249 3364 3481]\n",
+      " [3600 3721 3844 3969 4096 4225 4356 4489 4624 4761]\n",
+      " [4900 5041 5184 5329 5476 5625 5776 5929 6084 6241]\n",
+      " [6400 6561 6724 6889 7056 7225 7396 7569 7744 7921]\n",
+      " [8100 8281 8464 8649 8836 9025 9216 9409 9604 9801]]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%time\n",
+    "f(a,b)"
    ]
   }
  ],

--- a/1.ipynb
+++ b/1.ipynb
@@ -3,12 +3,12 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "cff3509d",
+   "id": "1680390a",
    "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np \n",
-    "import pandas as pd\n",
+    "#import pandas as pd\n",
     "import numba\n",
     "\n",
     "a = np.arange(0, 100).reshape((10, 10))"
@@ -17,7 +17,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "9b3ef87b",
+   "id": "310db278",
    "metadata": {},
    "outputs": [
     {
@@ -47,7 +47,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "8f80880e",
+   "id": "faa10de1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,7 +57,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "73b43faa",
+   "id": "1b3f8390",
    "metadata": {
     "scrolled": true
    },
@@ -88,13 +88,85 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "250ec6ac",
+   "execution_count": 8,
+   "id": "b41bf00e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 5 µs, sys: 5 µs, total: 10 µs\n",
+      "Wall time: 27.2 µs\n",
+      "[[   0    1    4    9   16   25   36   49   64   81]\n",
+      " [ 100  121  144  169  196  225  256  289  324  361]\n",
+      " [ 400  441  484  529  576  625  676  729  784  841]\n",
+      " [ 900  961 1024 1089 1156 1225 1296 1369 1444 1521]\n",
+      " [1600 1681 1764 1849 1936 2025 2116 2209 2304 2401]\n",
+      " [2500 2601 2704 2809 2916 3025 3136 3249 3364 3481]\n",
+      " [3600 3721 3844 3969 4096 4225 4356 4489 4624 4761]\n",
+      " [4900 5041 5184 5329 5476 5625 5776 5929 6084 6241]\n",
+      " [6400 6561 6724 6889 7056 7225 7396 7569 7744 7921]\n",
+      " [8100 8281 8464 8649 8836 9025 9216 9409 9604 9801]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "%time\n",
+    "print(a*b)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "cc136a95",
    "metadata": {},
    "outputs": [],
    "source": [
+    "@numba.jit\n",
+    "def f(x, y):\n",
+    "    print (x*y)\n",
+    "    return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "f2931e0c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 4 µs, sys: 1e+03 ns, total: 5 µs\n",
+      "Wall time: 14.1 µs\n",
+      "[[   0    1    4    9   16   25   36   49   64   81]\n",
+      " [ 100  121  144  169  196  225  256  289  324  361]\n",
+      " [ 400  441  484  529  576  625  676  729  784  841]\n",
+      " [ 900  961 1024 1089 1156 1225 1296 1369 1444 1521]\n",
+      " [1600 1681 1764 1849 1936 2025 2116 2209 2304 2401]\n",
+      " [2500 2601 2704 2809 2916 3025 3136 3249 3364 3481]\n",
+      " [3600 3721 3844 3969 4096 4225 4356 4489 4624 4761]\n",
+      " [4900 5041 5184 5329 5476 5625 5776 5929 6084 6241]\n",
+      " [6400 6561 6724 6889 7056 7225 7396 7569 7744 7921]\n",
+      " [8100 8281 8464 8649 8836 9025 9216 9409 9604 9801]]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
     "%time\n",
-    "a*b"
+    "f(a,b)"
    ]
   }
  ],


### PR DESCRIPTION
Numba jit compiler was used to speed up matrix multiplication, with two 10x10 NumPy arrays.